### PR TITLE
Fix entity name for activity payload

### DIFF
--- a/main.py
+++ b/main.py
@@ -102,7 +102,7 @@ async def post_screen_activity(payload: dict = Body(...)):
             "entity": {
                 "ParentId": {
                     "Id": contact_id,
-                    "EntityName": "Contacts"
+                    "EntityName": "Contact"
                 },
                 "VerbId": {
                     "Id": "2d4edbf9-a7a2-4174-ae53-a8f900bb0381",


### PR DESCRIPTION
## Summary
- fix `EntityName` for posting Screen activities

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6882294821f8833284a26b3f2b684a4f